### PR TITLE
Fix text overflowing horizontally by one character

### DIFF
--- a/src/name/bizna/ocmos/MMU.java
+++ b/src/name/bizna/ocmos/MMU.java
@@ -835,17 +835,14 @@ public class MMU implements Memory {
 			if(charToOutput != null) {
 				if(!didOutputChar) {
 					simpleVoidCall(mappedGPU, "set", cursorX, cursorY, charToOutput);
-					didOutputChar = true;
+					didOutputChar = true; // Still set to false by line 846 anyway?
 				}
 				// TODO: character width, sigh
-				int newCursorX = cursorX + 1;
-				if(newCursorX > (curW&0xFF)) {
-					if(autoLinebreak) {
-						newCursorX = 0;
-						linefeed();
-					}
+				cursorX++;
+				if(cursorX + 1 > (curW&0xFF) && autoLinebreak) {
+					cursorX = 0;
+					linefeed();
 				}
-				cursorX = newCursorX;
 				didOutputChar = false;
 				codeUnitPos = 0;
 			}


### PR DESCRIPTION
Original bug:

![Screenshot_20220604_213903](https://user-images.githubusercontent.com/25323231/172007775-157d555c-9a84-4e1e-8a2a-a826217838ef.png)

Original text for the second to third line: `[...] sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. [...]`

TODO: Test this PR. I don't have any idea how to compile Minecraft mods atm so someone else will have to do it.